### PR TITLE
Fix Snackbar appearance

### DIFF
--- a/app/src/main/java/ru/gaket/themoviedb/presentation/review/common/ReviewTextView.kt
+++ b/app/src/main/java/ru/gaket/themoviedb/presentation/review/common/ReviewTextView.kt
@@ -3,18 +3,18 @@ package ru.gaket.themoviedb.presentation.review.common
 import androidx.compose.foundation.layout.Arrangement.spacedBy
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material.Button
-import androidx.compose.material.ScaffoldState
+import androidx.compose.material.SnackbarHost
+import androidx.compose.material.SnackbarHostState
 import androidx.compose.material.Surface
 import androidx.compose.material.Text
-import androidx.compose.material.rememberScaffoldState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
@@ -43,62 +43,59 @@ internal fun ReviewTextView(
     isReviewTextEmpty: Boolean,
     onTextChange: (String) -> Unit,
     onSubmit: () -> Unit,
+    snackbarState: SnackbarHostState = remember { SnackbarHostState() },
 ) {
-
-    if (isReviewTextEmpty) ShowToastOnEmptyText()
-
-    Column(
-        verticalArrangement = spacedBy(dimensionResource(id = R.dimen.space_normal)),
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(all = dimensionResource(id = R.dimen.space_normal)),
-    ) {
-        Text(
-            text = title,
-            maxLines = 1,
-            fontSize = 24.sp,
-            overflow = TextOverflow.Ellipsis,
-        )
-        BasicTextField(
-            value = submittedReviewText,
-            onValueChange = onTextChange,
-            decorationBox = { innerTextField ->
-                Surface(
-                    elevation = 8.dp,
-                    shape = RoundedCornerShape(size = 12.dp),
-                ) {
-                    Box(
-                        modifier = Modifier.padding(
-                            horizontal = dimensionResource(id = R.dimen.space_normal),
-                            vertical = dimensionResource(id = R.dimen.space_medium),
-                        )
-                    ) {
-                        innerTextField()
-                    }
-                }
-            },
-            modifier = Modifier
-                .weight(weight = 1f)
-                .fillMaxWidth(),
-        )
-        Button(
-            onClick = { onSubmit() },
-            modifier = Modifier.fillMaxWidth(),
-        ) {
-            Text(text = stringResource(id = R.string.review_button_next))
+    if (isReviewTextEmpty) {
+        val message = stringResource(id = R.string.review_error_should_not_be_empty)
+        LaunchedEffect(snackbarState) {
+            snackbarState.showSnackbar(
+                message = message,
+            )
         }
     }
-}
 
-@Composable
-private fun ShowToastOnEmptyText(
-    scaffoldState: ScaffoldState = rememberScaffoldState(),
-) {
-    val message = stringResource(id = R.string.review_error_should_not_be_empty)
-
-    LaunchedEffect(scaffoldState.snackbarHostState) {
-        scaffoldState.snackbarHostState.showSnackbar(
-            message = message,
-        )
+    Column {
+        Column(
+            verticalArrangement = spacedBy(dimensionResource(id = R.dimen.space_normal)),
+            modifier = Modifier
+                .weight(weight = 1f)
+                .padding(all = dimensionResource(id = R.dimen.space_normal)),
+        ) {
+            Text(
+                text = title,
+                maxLines = 1,
+                fontSize = 24.sp,
+                overflow = TextOverflow.Ellipsis,
+            )
+            BasicTextField(
+                value = submittedReviewText,
+                onValueChange = onTextChange,
+                decorationBox = { innerTextField ->
+                    Surface(
+                        elevation = 8.dp,
+                        shape = RoundedCornerShape(size = 12.dp),
+                    ) {
+                        Box(
+                            modifier = Modifier.padding(
+                                horizontal = dimensionResource(id = R.dimen.space_normal),
+                                vertical = dimensionResource(id = R.dimen.space_medium),
+                            )
+                        ) {
+                            innerTextField()
+                        }
+                    }
+                },
+                modifier = Modifier
+                    .weight(weight = 1f)
+                    .fillMaxWidth(),
+            )
+            Button(
+                onClick = { onSubmit() },
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text(text = stringResource(id = R.string.review_button_next))
+            }
+        }
+        SnackbarHost(hostState = snackbarState)
     }
 }


### PR DESCRIPTION
Использовать для показа Snackbar ScaffoldState можно только внутри Scaffold Composable. Официальная дока тут https://developer.android.com/jetpack/compose/side-effects не зарстряет на этом внимание, но использует именно его. На скаффолд мы пока перейти не можем, т.к. хэдэр и текст - разные фрагменты. Зато можем использовать SnackbarHistState напрямую. Выглядит не идеально, работает тоже, но как есть.

По поводу не идеальности работы: я считаю, что гугл учит плохому. Они предлагают использовать стейт для показа снэкбара, но при этом не упоминают, что снэкбар показывается на какое-то время. ИМХО, правильно сделать одно из 2:
- Вынести флаг о показе снэкбара в отдельный Flow (не StateFlow), слушать его в эффекте и обновлять по нему стейт из эффекта
- Оставить флаг в стейте, но тогда перенести контроль показа времени в VM

Без любого из этих решений (я не проверял, но мне кажется, что оба должны работать), повторный клик на кнопку при пустом тексте не приведет к показу снэкбара.

Можно сделать фикс практическим заданием :) Этот как раз Advanced State.